### PR TITLE
Add API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# competition-management
+# Competition-Management
+XX 대회 관리를 위한 API 서버
+
+## Requirement
+1. 참가 신청을 할 수 있는 API
+2. 진행자가 각 참가자의 경기 결과를 기록할 수 있는 API
+3. 진행자가 각 참가자의 경기 결과를 수정할 수 있는 API
+4. 팀이 몇 점으로 몇 등했는지 확인 할 수 있는 API

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -1,0 +1,58 @@
+# Competitions
+대회(Competition) 관련 API 입니다.
+
+## The result object
+| name | type | description |
+| --- | --- | --- |
+| id | string | competition identifier |
+| teamScores | array | List of `teamScore`s |
+
+## The teamScore object
+| name | type | description |
+| --- | --- | --- |
+| teamId | string | team identifier |
+| teamName | string | team name |
+| score | number | team total score |
+| grade | number | team grade |
+
+## Get competition result
+Get a result of competition
+
+### Endpoints
+`GET /competitions/:competitionId/result`
+
+### Path Variables
+| name | type | description |
+| --- | --- | --- |
+| competitionId | string | (**required**) competition identifier |
+
+### Request Example
+
+```sh
+curl -X GET
+     "http://{end-point}/competitions/1/result"
+```
+
+### Response
+Retrieved result object on success, or error on failure.
+
+### Response Example
+``` json
+{
+  "competitionId": "1",
+  "teamScores" : [
+    {
+      "teamId": "a1b2c3c4",
+      "teamName": "FIFL",
+      "score": 500,
+      "grade": 1,
+    },
+    {
+      "teamId": "a1b2c3c5",
+      "teamName": "FIFL2",
+      "score": 450,
+      "grade": 2,
+    },
+  ],
+}
+```

--- a/docs/records.md
+++ b/docs/records.md
@@ -1,0 +1,117 @@
+# Records
+참가자(member)의 기록(record) 관련 API 입니다.
+
+## The record object
+| name | type | description |
+| --- | --- | --- |
+| competitionId | string | competition identifier |
+| teamId | string | team identifier |
+| memberId | string | member identifier |
+| round | number | round of event |
+| runningTime | number | running time in seconds |
+| sitUpCount | number | sit up total count |
+| pushUpCount | number | push up total count |
+
+## Create Record
+Create team member's record
+
+### Endpoints
+`POST /competitions/:competitionId/teams/:teamId/record`
+
+### Path Variables
+| name | type | description |
+| --- | --- | --- |
+| competitionId | string | (**required**) competition identifier |
+| teamId | string | (**required**) team identifier |
+
+### Body Parameters
+| name | type | description |
+| --- | --- | --- |
+| memberId | string | (**required**) member identifier |
+| round | number | (**required**) round of event |
+| runningTime | number | (**required**) in seconds |
+| sitUpCount | number | (**required**) sit up total count |
+| pushUpCount | number | (**required**) push up total count |
+
+### Request Example
+
+```sh
+curl -X POST
+    -H "accept-version: 2.0.0"
+    -H "Content-Type: application/json"
+    -d '{
+      "memberId": "1",
+      "round": 1,
+      "runningTime": 1110,
+      "sitUpCount": 56,
+      "pushUpCount": 80,
+    }'
+     "http://{end-point}/competitions/1/teams/a1b2c3d4/record"
+```
+
+### Response
+Created record object on success, or error on failure.
+
+### Response Example
+``` json
+{
+  "competitionId": "1",
+  "teamId": "1a2b3c4d",
+  "memberId": "1",
+  "round": 1,
+  "runningTime": 1110,
+  "sitUpCount": 56,
+  "pushUpCount": 80,
+}
+```
+
+## Update Record
+Update team member's record
+
+### Endpoints
+`PATCH /competitions/:competitionId/teams/:teamId/record`
+
+### Path Variables
+| name | type | description |
+| --- | --- | --- |
+| competitionId | string | (**required**) competition identifier |
+| teamId | string | (**required**) team identifier |
+
+### Body Parameters
+| name | type | description |
+| --- | --- | --- |
+| memberId | string | (**required**) member identifier |
+| round | number | (**required**) round of event |
+| runningTime | number | running time in seconds |
+| sitUpCount | number | sit up total count |
+| pushUpCount | number | push up total count |
+
+### Request Example
+
+```sh
+curl -X PATCH
+    -H "accept-version: 2.0.0"
+    -H "Content-Type: application/json"
+    -d '{
+      "memberId": "1",
+      "round": 1,
+      "sitUpCount": 70,
+    }'
+     "http://{end-point}/competitions/1/teams/a1b2c3d4/record"
+```
+
+### Response
+Updated record object on success, or error on failure.
+
+### Response Example
+``` json
+{
+  "competitionId": "1",
+  "teamId": "1a2b3c4d",
+  "memberId": "1",
+  "round": 1,
+  "runningTime": 1110,
+  "sitUpCount": 70,
+  "pushUpCount": 80,
+}
+```

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -1,0 +1,84 @@
+# Teams
+대회(Competition)에 참여한 team 관련 API입니다.
+
+## The team object
+| name | type | description |
+| --- | --- | --- |
+| id | string | team identifier |
+| competitionId | string | competition identifier |
+| name | string | team name |
+| city | string | the city that team belong to |
+| members | array | List of team `member`s |
+
+## The member object
+| name | type | description |
+| --- | --- | --- |
+| id | string | member's identifier for competition |
+| name | string | member's name |
+
+## Create team (= Register Team)
+Register a team for the competition by creating a team
+
+### Endpoints
+`POST /competitions/:competitionId/teams`
+
+### Path Variables
+| name | type | description |
+| --- | --- | --- |
+| competitionId | string | (**required**)competition identifier |
+
+### Body Parameters
+| name | type | description |
+| --- | --- | --- |
+| name | string | (**required**) team name |
+| city | string | (**required**) the city that team belong to |
+| members | array | (**required**) list of team member's name. The number of members should be **5**.|
+
+### Request Example
+
+```sh
+curl -X POST
+    -H "accept-version: 2.0.0"
+    -H "Content-Type: application/json"
+    -d '{
+      "name": "FIFL",
+      "city": "Seoul",
+      "members": ["차민철", "홍길동", "최준영", "김지헌", "김아라"],
+    }'
+    "http://{end-point}/competitions/1/teams"
+```
+
+### Response
+Created team object on success, or error on failure.
+
+### Response Example
+``` json
+{
+  "id": "1a2b3c4d",
+  "competitionId": "1",
+  "name": "FIFL",
+  "city": "Seoul",
+  "members" : [
+    {
+      "id": "1",
+      "name": "차민철",
+    },
+    {
+      "id": "2",
+      "name": "홍길동",
+    },
+    {
+      "id": "3",
+      "name": "최준영",
+    },
+    {
+      "id": "4",
+      "name": "김지헌",
+    },
+    {
+      "id": "5",
+      "name": "김아라",
+    },
+  ],
+}
+```


### PR DESCRIPTION
## Issue #1 
아래의 API Spec 정의 필요.
- `POST /competitions/:competitionId/teams`
- `POST /competitions/:competitionId/teams/:teamId/record`
- `PATCH /competitions/:competitionId/teams/:teamId/record`
- `GET /competitions/:competitionId/result`

## Change
- `docs/competitions.md` 추가 -  대회 관련 api
- `docs/teams.md` 추가 - 팀 관련 api
- `docs/records.md` 추가 - 기록 관련 api

## Note
