### PR TITLE
Add record table migration

### DIFF
--- a/schema/rdb/migrations/20191008092053-create-table-record.js
+++ b/schema/rdb/migrations/20191008092053-create-table-record.js
@@ -1,0 +1,50 @@
+const { sequelize } = require('../migration');
+
+const TABLENAME = 'record';
+
+module.exports = {
+    up: (queryInterface, Sequelize, done) => {
+        queryInterface.createTable(TABLENAME, {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            memberId: {
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'member',
+                    key: 'id',
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE',
+                allowNull: false,
+            },
+            round: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
+            runningTime: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
+            sitUpCount: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
+            pushUpCount: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                defaultValue: sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+                allowNull: false,
+            },
+        }).then((result) => done(null, result), (err) => done(err));
+    },
+    down: (queryInterface, Sequelize, done) => {
+        queryInterface.dropTable(TABLENAME)
+            .then((result) => done(null, result), (err) => done(err));
+    },
+};


### PR DESCRIPTION
## Issue #3 
* `record` 테이블 필요

## Change
* `record` 테이블 migration 추가

## How verified
### Record table
##### creation
```sh
$ npm run deploy:dev
```
```
+-------------+----------+------+-----+-------------------+-----------------------------+
| Field       | Type     | Null | Key | Default           | Extra                       |
+-------------+----------+------+-----+-------------------+-----------------------------+
| id          | int(11)  | NO   | PRI | NULL              | auto_increment              |
| memberId    | int(11)  | NO   | MUL | NULL              |                             |
| round       | int(11)  | NO   |     | NULL              |                             |
| runningTime | int(11)  | NO   |     | NULL              |                             |
| sitUpCount  | int(11)  | NO   |     | NULL              |                             |
| pushUpCount | int(11)  | NO   |     | NULL              |                             |
| updated_at  | datetime | NO   |     | CURRENT_TIMESTAMP | on update CURRENT_TIMESTAMP |
+-------------+----------+------+-----+-------------------+-----------------------------+
```
##### insertion (success)
```sql
insert into record (memberId, round, runningTime, sitUpCount, pushUpCount) values (1, 1, 1150, 56, 80);
select * from record;

+----+----------+-------+-------------+------------+-------------+---------------------+
| id | memberId | round | runningTime | sitUpCount | pushUpCount | updated_at          |
+----+----------+-------+-------------+------------+-------------+---------------------+
|  1 |        1 |     1 |        1150 |         56 |          80 | 2019-10-08 18:28:14 |
+----+----------+-------+-------------+------------+-------------+---------------------+
```
##### insertion (fail)
```sql
insert into record (round, runningTime, sitUpCount, pushUpCount) values (1, 1150, 56, 80);
ERROR 1364 (HY000): Field 'memberId' doesn't have a default value
```
```sql
insert into record (memberId, runningTime, sitUpCount, pushUpCount) values (1, 1150, 56, 80);
ERROR 1364 (HY000): Field 'round' doesn't have a default value
```
```sql
insert into record (memberId, round, sitUpCount, pushUpCount) values (1, 1, 56, 80);
ERROR 1364 (HY000): Field 'runningTime' doesn't have a default value
```
```sql
insert into record (memberId, round, runningTime, pushUpCount) values (1, 1, 1150, 80);
ERROR 1364 (HY000): Field 'sitUpCount' doesn't have a default value
```
```sql
insert into record (memberId, round, runningTime, sitUpCount) values (1, 1, 1150, 56);
ERROR 1364 (HY000): Field 'pushUpCount' doesn't have a default value
```
```sql
insert into record (memberId, round, runningTime, sitUpCount, pushUpCount) values (2, 1, 1150, 56, 80);
ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`competition_management`.`record`, CONSTRAINT `record_ibfk_1` FOREIGN KEY (`memberId`) REFERENCES `member` (`id`) ON DELETE CASCADE ON UPDATE CASCADE)
```
##### deletion
```sh
$ npm run undo:dev
```
```sql
desc record;
ERROR 1146 (42S02): Table 'competition_management.record' doesn't exist
```
## Note
